### PR TITLE
Automatically tag releases

### DIFF
--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -15,9 +15,8 @@ jobs:
           fetch-depth: "0"
 
       - name: Bump version and push tag
-        uses: anothrNick/github-tag-action@v1
+        uses: anothrNick/github-tag-action@f278d49d30cdd8775cc3e7dd00b5ee11686ee297 # v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DEFAULT_BUMP: patch
-          INITIAL_VERSION: 1.0.0
           WITH_V: false

--- a/README.md
+++ b/README.md
@@ -1,25 +1,30 @@
-# Brown D8React Integration
-Brown D8React Integration is a Drupal 8 module for handling the insertion of compiled react applications.
+# Brown Dreact
+Brown Dreact is a Drupal module for handling the insertion of compiled react applications.
 
 ## Installation
 
 Using Composer, Add the repository:
 
-```bash
+```json
 {
   "type": "vcs",
-  "url": "git@bitbucket.org:webserv/brown-d8react-integration.git"
+  "url": "git@bitbucket.org:BrownUniversity/dreact.git"
 }
 ```
 
 and require the module:
-```bash
+```json
 "require": {
-  "webserv/brown-d8react-integration": "dev-master"
+  "brownuniversity/dreact": "^1.0.0"
 }
 ```
 
 Run composer install, and the module will be available to be enabled via the Drupal interface.
+
+## Releases
+
+A new patch release will be automatically tagged when new code is pushed to the
+`main` branch.
 
 ## Usage
 

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "brownuniversity/dreact",
   "description": "Manages react apps for insertion into sites.",
-  "type": "drupal-custom-module",
+  "type": "drupal-module",
   "homepage": "https://github.com/brownuniversity/dreact",
   "minimum-stability": "dev"
 }


### PR DESCRIPTION
This adds (well, updates... I committed it to main first while making sure this was even going to work) a workflow to automatically tag releases when new code is pushed to the `main` branch.

This is related to https://github.com/BrownUniversity/pantheon-upstream-brownu/pull/405